### PR TITLE
reorder functions to get rid of warning

### DIFF
--- a/tetris.c
+++ b/tetris.c
@@ -147,16 +147,6 @@ tetris_print(struct tetris *t) {
     printf("\n");
 }
 
-void
-tetris_new_block(struct tetris *t) {
-    t->current=blocks[random()%TETRIS_PIECES];
-    t->x=(t->w/2) - (t->current.w/2);
-    t->y=0;
-    if (tetris_hittest(t)) {
-        t->gameover=1;
-    }
-}
-
 int
 tetris_hittest(struct tetris *t) {
     int x,y,X,Y;
@@ -175,6 +165,16 @@ tetris_hittest(struct tetris *t) {
             }
         }
     return 0;
+}
+
+void
+tetris_new_block(struct tetris *t) {
+    t->current=blocks[random()%TETRIS_PIECES];
+    t->x=(t->w/2) - (t->current.w/2);
+    t->y=0;
+    if (tetris_hittest(t)) {
+        t->gameover=1;
+    }
 }
 
 void


### PR DESCRIPTION
Reorder functions to get rid of warning: implicit declaration of function ‘tetris_hittest’.

I use this example when teaching CMake and it confuses workshop participants to see the warning since they think they did something wrong: https://coderefinery.github.io/cmake/04-exercise/